### PR TITLE
feat: 페이징 기능 추가, 세션 기반 로그인 유저 연동 로직 구현, HTTP파일 추가

### DIFF
--- a/api-test.http
+++ b/api-test.http
@@ -1,0 +1,182 @@
+### ✅ 회원가입
+POST http://localhost:8080/users
+Content-Type: application/json
+
+{
+  "email": "test@example.com",
+  "password": "1234",
+  "nickname": "테스터"
+}
+
+###
+
+### ✅ 로그인
+POST http://localhost:8080/users/login
+Content-Type: application/json
+
+{
+  "email": "test@example.com",
+  "password": "1234"
+}
+
+###
+
+### ✅ 로그아웃
+DELETE http://localhost:8080/users/logout
+
+
+###
+
+### ✅ 전체 유저 조회
+GET http://localhost:8080/users/all
+Accept: application/json
+Cookie-jar: session
+
+###
+
+### ✅ 특정 유저 조회
+GET http://localhost:8080/users/1
+Accept: application/json
+Cookie-jar: session
+
+###
+
+### ✅ 프로필 수정
+PUT http://localhost:8080/users/1
+Content-Type: application/json
+Cookie-jar: session
+
+{
+  "email": "newemail@example.com",
+  "nickname": "테스터변경"
+}
+
+###
+
+### ✅ 비밀번호 변경
+PATCH http://localhost:8080/users/1
+Content-Type: application/json
+Cookie-jar: session
+
+{
+  "oldPassword": "1234",
+  "newPassword": "12345"
+}
+
+###
+
+### ✅ 회원탈퇴
+DELETE http://localhost:8080/users/1
+password: 12345
+Cookie-jar: session
+
+###
+
+### ✅ 게시글 생성
+POST http://localhost:8080/feeds
+Content-Type: application/json
+Cookie-jar: session
+
+{
+  "title": "첫 번째 게시글입니다.",
+  "contents": "안녕하세요."
+}
+
+###
+
+### ✅ 게시글 전체 조회
+GET http://localhost:8080/feeds
+Accept: application/json
+Cookie-jar: session
+
+###
+
+### 페이지 0 (첫 페이지)
+GET http://localhost:8080/feeds?page=0
+Accept: application/json
+
+### 페이지 1 (두 번째 페이지)
+GET http://localhost:8080/feeds?page=1
+Accept: application/json
+
+### 페이지 2 (세 번째 페이지)
+GET http://localhost:8080/feeds?page=2
+Accept: application/json
+
+###
+
+### ✅ 게시글 단건 조회
+GET http://localhost:8080/feeds/1
+Accept: application/json
+Cookie-jar: session
+
+###
+
+### ✅ 게시글 수정
+PUT http://localhost:8080/feeds/1
+Content-Type: application/json
+Cookie-jar: session
+
+{
+  "title": "첫 번째 게시글 - 수정됨",
+  "contents": "내용 수정"
+}
+
+###
+
+### ✅ 게시글 삭제
+DELETE http://localhost:8080/feeds/1
+Cookie-jar: session
+
+###
+
+### ✅ 댓글 생성
+POST http://localhost:8080/comments
+Content-Type: application/json
+Cookie-jar: session
+
+{
+  "feedId": 1,
+  "contents": "댓글입니다."
+}
+
+###
+
+### ✅ 댓글 수정
+PUT http://localhost:8080/comments/1
+Content-Type: application/json
+Cookie-jar: session
+
+{
+  "contents": "댓글을 수정합니다."
+}
+
+###
+
+### ✅ 댓글 삭제
+DELETE http://localhost:8080/comments/1
+Cookie-jar: session
+
+###
+
+### ✅ 게시글 좋아요 등록
+POST http://localhost:8080/likes/feeds/1
+Cookie-jar: session
+
+###
+
+### ✅ 게시글 좋아요 취소
+DELETE http://localhost:8080/likes/feeds/1
+Cookie-jar: session
+
+###
+
+### ✅ 댓글 좋아요 등록
+POST http://localhost:8080/likes/comments/1
+Cookie-jar: session
+
+###
+
+### ✅ 댓글 좋아요 취소
+DELETE http://localhost:8080/likes/comments/1
+Cookie-jar: session

--- a/src/main/java/org/example/newsfeedproject/feed/controller/FeedController.java
+++ b/src/main/java/org/example/newsfeedproject/feed/controller/FeedController.java
@@ -1,11 +1,18 @@
 package org.example.newsfeedproject.feed.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.example.newsfeedproject.feed.dto.FeedRequestDto;
 import org.example.newsfeedproject.feed.dto.FeedResponseDto;
 import org.example.newsfeedproject.feed.service.FeedService;
+import org.example.newsfeedproject.user.dto.SessionUserDto;
+import org.example.newsfeedproject.user.entity.User;
+import org.example.newsfeedproject.user.repository.UserRepository;
+import org.example.newsfeedproject.user.constant.Const;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,10 +29,16 @@ import java.util.List;
 public class FeedController {
 
     private final FeedService feedService;
+    private final UserRepository userRepository;
 
     @PostMapping
-    public ResponseEntity<FeedResponseDto> createFeed(@RequestBody FeedRequestDto requestDto) {
-        return ResponseEntity.ok(feedService.createFeed(requestDto, null)); // 인증 미적용 → user = null
+    public ResponseEntity<FeedResponseDto> createFeed(
+            @RequestBody FeedRequestDto requestDto,
+            HttpServletRequest request
+    ) {
+        // 세션에서 로그인된 유저 정보 추출
+        User user = getSessionUser(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(feedService.createFeed(requestDto, user));
     }
 
     @GetMapping("/{id}")
@@ -50,14 +63,37 @@ public class FeedController {
     @PutMapping("/{id}")
     public ResponseEntity<FeedResponseDto> updateFeed(
             @PathVariable Long id,
-            @RequestBody FeedRequestDto requestDto
+            @RequestBody FeedRequestDto requestDto,
+            HttpServletRequest request
     ) {
-        return ResponseEntity.ok(feedService.updateFeed(id, requestDto, null)); // 인증 미적용
+        // 세션에서 로그인된 유저 정보 추출
+        User user = getSessionUser(request);
+        return ResponseEntity.ok(feedService.updateFeed(id, requestDto, user));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteFeed(@PathVariable Long id) {
-        feedService.deleteFeed(id, null); // 인증 미적용
+    public ResponseEntity<Void> deleteFeed(
+            @PathVariable Long id,
+            HttpServletRequest request
+    ) {
+        // 세션에서 로그인된 유저 정보 추출
+        User user = getSessionUser(request);
+        feedService.deleteFeed(id, user);
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 세션에서 로그인한 유저 정보를 가져와 User 엔티티로 반환
+     * @param request Http 요청 객체
+     * @return 로그인한 User 엔티티
+     */
+    private User getSessionUser(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session == null || session.getAttribute(Const.USER) == null) {
+            throw new IllegalArgumentException("로그인 후 이용해 주세요.");
+        }
+
+        SessionUserDto sessionUserDto = (SessionUserDto) session.getAttribute(Const.USER);
+        return userRepository.findByIdOrElseThrow(sessionUserDto.getId());
     }
 }

--- a/src/main/java/org/example/newsfeedproject/feed/controller/FeedController.java
+++ b/src/main/java/org/example/newsfeedproject/feed/controller/FeedController.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.example.newsfeedproject.feed.dto.FeedRequestDto;
 import org.example.newsfeedproject.feed.dto.FeedResponseDto;
 import org.example.newsfeedproject.feed.service.FeedService;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,9 +33,18 @@ public class FeedController {
         return ResponseEntity.ok(feedService.getFeed(id));
     }
 
+    /**
+     * 전체 게시글 목록 조회 API (페이징 처리 + 최신순)
+     *
+     * @param page 페이지 번호 (0부터 시작)
+     * @return FeedResponseDto 리스트
+     */
     @GetMapping
-    public ResponseEntity<List<FeedResponseDto>> getAllFeeds() {
-        return ResponseEntity.ok(feedService.getAllFeeds());
+    public ResponseEntity<List<FeedResponseDto>> getAllFeeds(
+            @RequestParam(defaultValue = "0") int page
+    ) {
+        PageRequest pageRequest = PageRequest.of(page, 10, Sort.by("createdAt").descending());
+        return ResponseEntity.ok(feedService.getFeedsByPage(pageRequest));
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/org/example/newsfeedproject/feed/repository/FeedRepository.java
+++ b/src/main/java/org/example/newsfeedproject/feed/repository/FeedRepository.java
@@ -1,6 +1,8 @@
 package org.example.newsfeedproject.feed.repository;
 
 import org.example.newsfeedproject.feed.entity.Feed;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -27,4 +29,12 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
      * 페이지네이션 처리는 Service 단에서 Pageable로 처리
      */
     List<Feed> findAllByOrderByCreatedAtDesc();
+
+    /**
+     * 전체 게시글을 생성일 기준으로 내림차순 정렬하여 페이징 처리하여 반환
+     *
+     * @param pageable 페이지 정보
+     * @return 페이징된 게시글 목록
+     */
+    Page<Feed> findAllByOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/org/example/newsfeedproject/feed/service/FeedService.java
+++ b/src/main/java/org/example/newsfeedproject/feed/service/FeedService.java
@@ -6,6 +6,7 @@ import org.example.newsfeedproject.feed.dto.FeedResponseDto;
 import org.example.newsfeedproject.feed.entity.Feed;
 import org.example.newsfeedproject.feed.repository.FeedRepository;
 import org.example.newsfeedproject.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,37 +24,18 @@ public class FeedService {
 
     private final FeedRepository feedRepository;
 
-    /**
-     * 게시글 새로 생성
-     *
-     * @param requestDto 사용자가 입력한 제목/내용
-     * @param user 현재 로그인한 사용자 (null 허용 → 예외 처리)
-     * @return 생성된 게시글 정보
-     */
     public FeedResponseDto createFeed(FeedRequestDto requestDto, User user) {
         validateUser(user); // 인증되지 않은 유저 차단
-
         Feed feed = new Feed(user, requestDto.getTitle(), requestDto.getContents());
         Feed savedFeed = feedRepository.save(feed);
         return new FeedResponseDto(savedFeed);
     }
 
-    /**
-     * 게시글 단건 조회
-     *
-     * @param id 게시글 ID
-     * @return 조회된 게시글 정보
-     */
     public FeedResponseDto getFeed(Long id) {
         Feed feed = findFeed(id);
         return new FeedResponseDto(feed);
     }
 
-    /**
-     * 전체 게시글을 최신순으로 조회
-     *
-     * @return 게시글 리스트
-     */
     public List<FeedResponseDto> getAllFeeds() {
         return feedRepository.findAllByOrderByCreatedAtDesc().stream()
                 .map(FeedResponseDto::new)
@@ -61,65 +43,44 @@ public class FeedService {
     }
 
     /**
-     * 게시글 수정
+     * 전체 게시글을 페이징 처리하여 최신순으로 조회
      *
-     * @param id 수정할 게시글 ID
-     * @param requestDto 수정할 제목/내용
-     * @param user 현재 로그인한 사용자 (null 허용 → 예외 처리)
-     * @return 수정된 게시글 정보
+     * @param pageable 페이지 정보
+     * @return 페이징된 게시글 리스트
      */
+    public List<FeedResponseDto> getFeedsByPage(Pageable pageable) {
+        return feedRepository.findAllByOrderByCreatedAtDesc(pageable).stream()
+                .map(FeedResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
     @Transactional
     public FeedResponseDto updateFeed(Long id, FeedRequestDto requestDto, User user) {
         validateUser(user); // 인증되지 않은 유저 차단
-
         Feed feed = findFeed(id);
         validateWriter(feed, user); // 작성자 확인
         feed.update(requestDto.getTitle(), requestDto.getContents());
         return new FeedResponseDto(feed);
     }
 
-    /**
-     * 게시글 삭제
-     *
-     * @param id 삭제할 게시글 ID
-     * @param user 현재 로그인한 사용자 (null 허용 → 예외 처리)
-     */
     public void deleteFeed(Long id, User user) {
         validateUser(user); // 인증되지 않은 유저 차단
-
         Feed feed = findFeed(id);
         validateWriter(feed, user); // 작성자 확인
         feedRepository.delete(feed);
     }
 
-    /**
-     * 게시글 ID로 게시글을 조회
-     *
-     * @param id 게시글 ID
-     * @return Feed 객체
-     */
     private Feed findFeed(Long id) {
         return feedRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
     }
 
-    /**
-     * 게시글의 작성자가 현재 사용자와 같은지 검증
-     *
-     * @param feed 게시글 객체
-     * @param user 현재 로그인한 사용자
-     */
     private void validateWriter(Feed feed, User user) {
         if (!feed.getUser().getId().equals(user.getId())) {
             throw new IllegalArgumentException("작성자만 수정/삭제할 수 있습니다.");
         }
     }
 
-    /**
-     * 유저가 null인 경우 예외 발생 (스프링 시큐리티 미적용 상태 고려)
-     *
-     * @param user 현재 로그인한 사용자
-     */
     private void validateUser(User user) {
         if (user == null) {
             throw new IllegalArgumentException("로그인 후 이용해 주세요.");


### PR DESCRIPTION
1. 게시글 목록 조회 페이징 기능 구현
   - `/feeds?page=0` 형식으로 요청 시 10개 단위로 최신순 정렬
   - `PageRequest`를 이용한 동적 페이징 처리

2. 로그인한 유저 세션 기반으로 게시글 생성/수정/삭제 가능하도록 로직 구현
   - FeedController에서 HttpServletRequest를 통해 세션 유저 조회
   - FeedService 내 유저 검증 및 작성자 확인 로직 추가
   - 미로그인 시 IllegalArgumentException 발생 처리

3. HTTP 요청 테스트용 `.http` 파일 추가
   - Postman 대체용 인텔리제이 내 http파일에서 `▶ Run` 버튼 클릭 시 사용 가능
   - 세션 쿠키 기반 인증 확인 가능

테스트는 IntelliJ에서 `.http` 파일로 바로 실행 가능하며, 쿠키는 자동 보존되어 로그인 후 활용
